### PR TITLE
Proposed code change for LCARSbuttonsClass.Flash()

### DIFF
--- a/LCARSbuttons/LCARSbuttons/Classes/Generic Button.vb
+++ b/LCARSbuttons/LCARSbuttons/Classes/Generic Button.vb
@@ -325,6 +325,7 @@ Public Class LCARSbuttonClass
                     flasher.Start()
                 Else
                     flasher.Abort()
+                    isFlashing = False
                     Lit = litBuffer
                 End If
             End If


### PR DESCRIPTION
Suggested code change to handle unwanted button state when using LCARSbuttons for other applications.

In this case, button gets stuck in "dim" state when LCARSbuttonsClass.Flash() is set to false during dim state. This is due to "isFlashing" never being reset out of "True" (ie, when the button is "dim") and the Button refresh specifically has "If isLit XOR isFlashing" for determining redraw state.

When isFlashing is null or false, the isLit state then determines button draw state of "dim" or not.